### PR TITLE
 feat [#8]: add live demo on landing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/styled": "^11.13.0",
         "@mui/icons-material": "^6.1.7",
         "@mui/material": "^6.1.7",
+        "nigeria-state-lga-data": "^1.1.5",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -50,7 +51,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -367,7 +367,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -411,7 +410,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -986,7 +984,6 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.5.0.tgz",
       "integrity": "sha512-yjvtXoFcrPLGtgKRxFaH6OQPtcLPhkloC0BML6rBG5UeldR0nPULR/2E2BfXdo5JNV7j7lOzrrLX2Qf/iSidow==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@mui/core-downloads-tracker": "^6.5.0",
@@ -1650,7 +1647,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -2060,6 +2056,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/nigeria-state-lga-data": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/nigeria-state-lga-data/-/nigeria-state-lga-data-1.1.5.tgz",
+      "integrity": "sha512-6k82HPN5vB6erA6vMTWl4Ab3yflrd2rmS5+5qI6JurPGRHBX1eKwdqtv4QWK3nHQGxAmdG+u5uRjJZXvJWKBog==",
+      "license": "MIT"
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -2133,7 +2135,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2192,7 +2193,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2205,7 +2205,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -2427,7 +2426,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@emotion/styled": "^11.13.0",
     "@mui/icons-material": "^6.1.7",
     "@mui/material": "^6.1.7",
+    "nigeria-state-lga-data": "^1.1.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ import CodeIcon from '@mui/icons-material/Code'
 import DownloadIcon from '@mui/icons-material/Download'
 import PublicIcon from '@mui/icons-material/Public'
 import BoltIcon from '@mui/icons-material/Bolt'
+import DemoTester from './components/DemoTester';
 
 function CodeBlock({ children }) {
   const [copied, setCopied] = useState(false)
@@ -29,7 +30,7 @@ function CodeBlock({ children }) {
         size="small"
         variant="contained"
         color="primary"
-        onClick={() => { navigator.clipboard.writeText(children); setCopied(true); setTimeout(()=>setCopied(false), 1200) }}
+        onClick={() => { navigator.clipboard.writeText(children); setCopied(true); setTimeout(() => setCopied(false), 1200) }}
         sx={{ position: 'absolute', top: 8, right: 8, textTransform: 'none' }}
       >
         {copied ? 'Copied' : 'Copy'}
@@ -53,53 +54,53 @@ export default function App() {
     <ThemeProvider theme={theme}>
       <CssBaseline />
       <Box sx={{ minHeight: '100vh', bgcolor: 'background.default' }}>
-      <Box component="header" sx={{ borderBottom: 1, borderColor: 'divider', bgcolor: 'background.paper' }}>
-        <Container maxWidth="lg" sx={{ py: 1.5, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-          <Stack direction="row" spacing={1} alignItems="center">
-            <Chip label="NG" color="success" sx={{ fontWeight: 700 }} />
-            <Typography variant="h6" sx={{ fontWeight: 700 }}>Nigeria State Data</Typography>
-          </Stack>
-          <Stack direction="row" spacing={2}>
-            <Link href="https://www.npmjs.com/package/nigeria-state-lga-data" target="_blank" underline="hover" color="primary">NPM</Link>
-            <Link href="https://github.com/CodeLeom/nigeria-state-city-lga" target="_blank" underline="hover" color="primary">GitHub</Link>
-          </Stack>
-        </Container>
-      </Box>
+        <Box component="header" sx={{ borderBottom: 1, borderColor: 'divider', bgcolor: 'background.paper' }}>
+          <Container maxWidth="lg" sx={{ py: 1.5, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Stack direction="row" spacing={1} alignItems="center">
+              <Chip label="NG" color="success" sx={{ fontWeight: 700 }} />
+              <Typography variant="h6" sx={{ fontWeight: 700 }}>Nigeria State Data</Typography>
+            </Stack>
+            <Stack direction="row" spacing={2}>
+              <Link href="https://www.npmjs.com/package/nigeria-state-lga-data" target="_blank" underline="hover" color="primary">NPM</Link>
+              <Link href="https://github.com/CodeLeom/nigeria-state-city-lga" target="_blank" underline="hover" color="primary">GitHub</Link>
+            </Stack>
+          </Container>
+        </Box>
 
         <Container maxWidth="lg" sx={{ py: 6 }}>
-        <Paper variant="outlined" sx={{
+          <Paper variant="outlined" sx={{
             p: { xs: 3, md: 5 },
             textAlign: 'center',
             background: `linear-gradient(180deg, ${green[50]}, #fff)`
           }}>
-          <Stack spacing={1} alignItems="center">
-            <Stack direction="row" spacing={1}>
-              <Chip label="Stable API" size="small" color="success" variant="outlined" />
-              <Chip label="Zero dependencies" size="small" color="success" variant="outlined" />
-            </Stack>
-            <Typography variant="h3" sx={{ fontWeight: 800, letterSpacing: -0.5 }}>Nigerian States, LGAs, and Towns</Typography>
-            <Typography color="text.secondary">Lightweight Node package with clean helpers for states, LGAs, capitals, and towns.</Typography>
-            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5} justifyContent="center" sx={{ mt: 1 }}>
-              <Button color="primary" variant="contained" startIcon={<DownloadIcon />} href="https://www.npmjs.com/package/nigeria-state-lga-data" target="_blank">Install</Button>
-              <Button color="primary" variant="outlined" startIcon={<PublicIcon />} href="https://github.com/CodeLeom/nigeria-state-city-lga" target="_blank">Repository</Button>
-            </Stack>
-          </Stack>
-          <Box sx={{ mt: 3 }}>
-            <CodeBlock>{`npm i nigeria-state-lga-data`}</CodeBlock>
-            <Typography variant="body2" color="text.secondary" sx={{ mt: 1, textAlign: 'center' }}>or</Typography>
-            <CodeBlock>{`yarn add nigeria-state-lga-data`}</CodeBlock>
-          </Box>
-        </Paper>
-
-        <Stack spacing={3} sx={{ mt: 5 }}>
-          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={3}>
-            <Paper variant="outlined" sx={{ p: 3, flex: 1 }}>
-              <Stack direction="row" spacing={1} alignItems="center">
-                <CodeIcon fontSize="small" />
-                <Typography variant="subtitle2">Usage (Node.js)</Typography>
+            <Stack spacing={1} alignItems="center">
+              <Stack direction="row" spacing={1}>
+                <Chip label="Stable API" size="small" color="success" variant="outlined" />
+                <Chip label="Zero dependencies" size="small" color="success" variant="outlined" />
               </Stack>
-              <Box sx={{ mt: 1.5 }}>
-                <CodeBlock>{`const {
+              <Typography variant="h3" sx={{ fontWeight: 800, letterSpacing: -0.5 }}>Nigerian States, LGAs, and Towns</Typography>
+              <Typography color="text.secondary">Lightweight Node package with clean helpers for states, LGAs, capitals, and towns.</Typography>
+              <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5} justifyContent="center" sx={{ mt: 1 }}>
+                <Button color="primary" variant="contained" startIcon={<DownloadIcon />} href="https://www.npmjs.com/package/nigeria-state-lga-data" target="_blank">Install</Button>
+                <Button color="primary" variant="outlined" startIcon={<PublicIcon />} href="https://github.com/CodeLeom/nigeria-state-city-lga" target="_blank">Repository</Button>
+              </Stack>
+            </Stack>
+            <Box sx={{ mt: 3 }}>
+              <CodeBlock>{`npm i nigeria-state-lga-data`}</CodeBlock>
+              <Typography variant="body2" color="text.secondary" sx={{ mt: 1, textAlign: 'center' }}>or</Typography>
+              <CodeBlock>{`yarn add nigeria-state-lga-data`}</CodeBlock>
+            </Box>
+          </Paper>
+
+          <Stack spacing={3} sx={{ mt: 5 }}>
+            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={3}>
+              <Paper variant="outlined" sx={{ p: 3, flex: 1 }}>
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <CodeIcon fontSize="small" />
+                  <Typography variant="subtitle2">Usage (Node.js)</Typography>
+                </Stack>
+                <Box sx={{ mt: 1.5 }}>
+                  <CodeBlock>{`const {
   getStates,
   getStatesAndCapitals,
   getLgas,
@@ -116,48 +117,51 @@ console.log(getCapital('Rivers'));        // 'Port Harcourt'
 console.log(getState('Oyo'));             // { name, capital, lgas, towns }
 console.log(getStatesData().length);      // 36
 `}</CodeBlock>
-              </Box>
-            </Paper>
+                </Box>
+              </Paper>
 
-            <Paper variant="outlined" sx={{ p: 3, flex: 1 }}>
-              <Stack direction="row" spacing={1} alignItems="center">
-                <BoltIcon fontSize="small" />
-                <Typography variant="subtitle2">API Surface</Typography>
-              </Stack>
-              <List dense sx={{ mt: 1 }}>
-                <ListItem><ListItemIcon><CodeIcon fontSize="small" /></ListItemIcon><ListItemText primary="getStates() → string[]" /></ListItem>
-                <ListItem><ListItemIcon><CodeIcon fontSize="small" /></ListItemIcon><ListItemText primary="getStatesAndCapitals() → { state, capital }[]" /></ListItem>
-                <ListItem><ListItemIcon><CodeIcon fontSize="small" /></ListItemIcon><ListItemText primary="getLgas(state) → string[]" /></ListItem>
-                <ListItem><ListItemIcon><CodeIcon fontSize="small" /></ListItemIcon><ListItemText primary="getTowns(state) → string[]" /></ListItem>
-                <ListItem><ListItemIcon><CodeIcon fontSize="small" /></ListItemIcon><ListItemText primary="getCapital(state) → string" /></ListItem>
-                <ListItem><ListItemIcon><CodeIcon fontSize="small" /></ListItemIcon><ListItemText primary="getState(state) → State" /></ListItem>
-                <ListItem><ListItemIcon><CodeIcon fontSize="small" /></ListItemIcon><ListItemText primary="getStatesData() → State[]" /></ListItem>
-              </List>
+              <Paper variant="outlined" sx={{ p: 3, flex: 1 }}>
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <BoltIcon fontSize="small" />
+                  <Typography variant="subtitle2">API Surface</Typography>
+                </Stack>
+                <List dense sx={{ mt: 1 }}>
+                  <ListItem><ListItemIcon><CodeIcon fontSize="small" /></ListItemIcon><ListItemText primary="getStates() → string[]" /></ListItem>
+                  <ListItem><ListItemIcon><CodeIcon fontSize="small" /></ListItemIcon><ListItemText primary="getStatesAndCapitals() → { state, capital }[]" /></ListItem>
+                  <ListItem><ListItemIcon><CodeIcon fontSize="small" /></ListItemIcon><ListItemText primary="getLgas(state) → string[]" /></ListItem>
+                  <ListItem><ListItemIcon><CodeIcon fontSize="small" /></ListItemIcon><ListItemText primary="getTowns(state) → string[]" /></ListItem>
+                  <ListItem><ListItemIcon><CodeIcon fontSize="small" /></ListItemIcon><ListItemText primary="getCapital(state) → string" /></ListItem>
+                  <ListItem><ListItemIcon><CodeIcon fontSize="small" /></ListItemIcon><ListItemText primary="getState(state) → State" /></ListItem>
+                  <ListItem><ListItemIcon><CodeIcon fontSize="small" /></ListItemIcon><ListItemText primary="getStatesData() → State[]" /></ListItem>
+                </List>
+              </Paper>
+            </Stack>
+
+            <Paper variant="outlined" sx={{ p: 3 }}>
+              <Typography variant="subtitle2">Note</Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+                Towns are listed at the state level. Towns-per-LGA lookups may be added by contributors later.
+              </Typography>
             </Paper>
           </Stack>
 
-          <Paper variant="outlined" sx={{ p: 3 }}>
-            <Typography variant="subtitle2">Note</Typography>
-            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
-              Towns are listed at the state level. Towns-per-LGA lookups may be added by contributors later.
-            </Typography>
-          </Paper>
-        </Stack>
+          <Divider sx={{ my: 5 }} />
 
-        <Divider sx={{ my: 5 }} />
-
-        <Stack direction="row" spacing={1.5} justifyContent="center">
-          <Button color="primary" variant="contained" href="https://www.npmjs.com/package/nigeria-state-lga-data" target="_blank">View on NPM</Button>
-          <Button color="primary" variant="outlined" href="https://github.com/CodeLeom/nigeria-state-city-lga" target="_blank">GitHub Repo</Button>
-        </Stack>
-      </Container>
-
-      <Box component="footer" sx={{ borderTop: 1, borderColor: 'divider', bgcolor: 'background.paper', mt: 6 }}>
-        <Container maxWidth="lg" sx={{ py: 3 }}>
-          <Typography variant="caption" color="text.secondary">MIT Licensed. Built with Vite & Material UI.</Typography>
+          <Stack direction="row" spacing={1.5} justifyContent="center">
+            <Button color="primary" variant="contained" href="https://www.npmjs.com/package/nigeria-state-lga-data" target="_blank">View on NPM</Button>
+            <Button color="primary" variant="outlined" href="https://github.com/CodeLeom/nigeria-state-city-lga" target="_blank">GitHub Repo</Button>
+          </Stack>
         </Container>
+
+        <DemoTester />
+
+
+        <Box component="footer" sx={{ borderTop: 1, borderColor: 'divider', bgcolor: 'background.paper', mt: 6 }}>
+          <Container maxWidth="lg" sx={{ py: 3 }}>
+            <Typography variant="caption" color="text.secondary">MIT Licensed. Built with Vite & Material UI.</Typography>
+          </Container>
+        </Box>
       </Box>
-    </Box>
     </ThemeProvider>
   )
 }

--- a/src/components/DemoTester.jsx
+++ b/src/components/DemoTester.jsx
@@ -1,0 +1,165 @@
+"use client";
+import React, { useState } from "react";
+import {
+  Box, Tabs, Tab, Typography, Paper, Select, MenuItem, FormControl, InputLabel,
+  Stack, TableContainer, Table, TableHead, TableRow, TableCell, TableBody, Chip
+} from "@mui/material";
+
+import {
+  getStates, getStatesAndCapitals, getLgas, getTowns,
+  getCapital, getState, getStatesData,
+} from "nigeria-state-lga-data";
+
+function TabPanel({ children, value, index }) {
+  return value === index ? <Box sx={{ mt: 2 }}>{children}</Box> : null;
+}
+
+export default function DemoTester() {
+  const states = getStates();
+  const [tab, setTab] = useState(0);
+  const savedState = localStorage.getItem("selectedState");
+  const [selectedState, setSelectedState] = useState(savedState || "");
+
+  const handleTabChange = (_, newValue) => setTab(newValue);
+  const handleStateChange = (event) => {
+    setSelectedState(event.target.value);
+    localStorage.setItem("selectedState", event.target.value);
+  }
+
+  // Fonction helper pour afficher LGAs ou Towns en Chip
+  const renderChips = (items) => (
+    <Stack direction="row" flexWrap="wrap" spacing={2} sx={{ mt: 1 }}>
+      {items.map(item => <Chip key={item} label={item} size="small" sx={{ mb: 5 }} />)}
+    </Stack>
+  );
+
+  return (
+    <Paper variant="outlined" sx={{
+      m: { xs: 2, md: 12 },
+      mt: 6,
+      p: { xs: 2, md: 3 },
+      borderColor: 'rgb(88%, 88%, 88%)',
+      borderWidth: 1,
+      borderStyle: 'solid',
+      borderRadius: 2,
+    }}>
+      <Typography variant="h6" sx={{ mb: 2 }}>
+        Interactive Demo – Test All Methods
+      </Typography>
+
+      <Tabs
+        value={tab}
+        onChange={handleTabChange}
+        variant="scrollable"
+        scrollButtons="auto"
+        sx={{ mb: 2 }}
+      >
+        {["getStates()", "getStatesAndCapitals()", "getLgas(state)", "getTowns(state)", "getCapital(state)", "getState(state)", "getStatesData()"]
+          .map((label, i) => (
+            <Tab key={i} label={label} sx={{ minWidth: 140 }} />
+        ))}
+      </Tabs>
+
+      {/* getStates() */}
+      <TabPanel value={tab} index={0}>
+        <Typography>All States:</Typography>
+        {renderChips(getStates())}
+      </TabPanel>
+
+      {/* getStatesAndCapitals() */}
+      <TabPanel value={tab} index={1}>
+        <Typography>States and Capitals:</Typography>
+        <TableContainer sx={{ mt: 1, maxHeight: 300 }}>
+          <Table size="small" stickyHeader>
+            <TableHead>
+              <TableRow>
+                <TableCell>State</TableCell>
+                <TableCell>Capital</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {getStatesAndCapitals().map(({ state, capital }) => (
+                <TableRow key={state}>
+                  <TableCell>{state}</TableCell>
+                  <TableCell>{capital}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </TabPanel>
+
+      {/* getLgas(state) */}
+      <TabPanel value={tab} index={2}>
+        <FormControl fullWidth sx={{ mb: 2 }}>
+          <InputLabel>Select State</InputLabel>
+          <Select value={selectedState} label="Select State" onChange={handleStateChange}>
+            {states.map((s) => <MenuItem key={s} value={s}>{s}</MenuItem>)}
+          </Select>
+        </FormControl>
+        {selectedState && (
+          <Box>
+            <Typography>LGAs of {selectedState}:</Typography>
+            <Box sx={{ maxHeight: 200, overflowY: 'auto', mt: 1 }}>
+              {renderChips(getLgas(selectedState))}
+            </Box>
+          </Box>
+        )}
+      </TabPanel>
+
+      {/* getTowns(state) */}
+      <TabPanel value={tab} index={3}>
+        <FormControl fullWidth sx={{ mb: 2 }}>
+          <InputLabel>Select State</InputLabel>
+          <Select value={selectedState} label="Select State" onChange={handleStateChange}>
+            {states.map((s) => <MenuItem key={s} value={s}>{s}</MenuItem>)}
+          </Select>
+        </FormControl>
+        {selectedState && (
+          <Box>
+            <Typography>Towns of {selectedState}:</Typography>
+            <Box sx={{ maxHeight: 200, overflowY: 'auto', mt: 1 }}>
+              {renderChips(getTowns(selectedState))}
+            </Box>
+          </Box>
+        )}
+      </TabPanel>
+
+      {/* getCapital(state) */}
+      <TabPanel value={tab} index={4}>
+        <FormControl fullWidth sx={{ mb: 2 }}>
+          <InputLabel>Select State</InputLabel>
+          <Select value={selectedState} label="Select State" onChange={handleStateChange}>
+            {states.map((s) => <MenuItem key={s} value={s}>{s}</MenuItem>)}
+          </Select>
+        </FormControl>
+        {selectedState && (
+          <Typography>Capital of {selectedState}: <strong>{getCapital(selectedState)}</strong></Typography>
+        )}
+      </TabPanel>
+
+      {/* getState(state) */}
+      <TabPanel value={tab} index={5}>
+        <FormControl fullWidth sx={{ mb: 2 }}>
+          <InputLabel>Select State</InputLabel>
+          <Select value={selectedState} label="Select State" onChange={handleStateChange}>
+            {states.map((s) => <MenuItem key={s} value={s}>{s}</MenuItem>)}
+          </Select>
+        </FormControl>
+        {selectedState && (
+          <Box sx={{ bgcolor: "#f5f5f5", p: 2, borderRadius: 1, maxHeight: 300, overflow: 'auto' }}>
+            <pre>{JSON.stringify(getState(selectedState), null, 2)}</pre>
+          </Box>
+        )}
+      </TabPanel>
+
+      {/* getStatesData() */}
+      <TabPanel value={tab} index={6}>
+        <Typography>All States Data:</Typography>
+        <Box sx={{ maxHeight: 400, overflow: "auto", mt: 1, bgcolor: "#f5f5f5", p: 2, borderRadius: 1 }}>
+          <pre>{JSON.stringify(getStatesData(), null, 2)}</pre>
+        </Box>
+      </TabPanel>
+    </Paper>
+  );
+}


### PR DESCRIPTION
> [!CAUTION]
>  Don't merge now

PR: Add Interactive Demo Page for Testing Library Methods

## **Overview**

This Pull Request implements the interactive demo requested in Issue **#8**.
The goal of the issue was to provide developers with a way to **test the library directly on the landing page or a dedicated demo page**, allowing them to quickly verify states, capitals, LGAs, towns, and other data provided by the package.

This PR adds a complete, functional demo interface that covers all available methods of the library.

---

## What This PR Adds

###  Full Demo Tester Component

A new interactive UI where developers can:

* List all states
* View state–capital pairs
* Select a state to view:

  * LGAs
  * Towns
  * Capital
  * Full state object
* Inspect the full `getStatesData()` output

The demo mirrors all library methods, making it easy for developers to validate the data in real time.

---

##  UI/UX Enhancements

To keep the demo clean and easy to use:

* Added responsive tabs
* Wrapped large outputs in scrollable containers
* Used Material UI for a clean and consistent interface
* Reduced excessive vertical scrolling
* Ensured a smooth experience on both desktop and mobile

---

##  Why This Feature Matters

This demo:

* Helps developers quickly confirm that the library fits their needs
* Improves the onboarding experience
* Makes the documentation more interactive
* Provides transparency about the dataset

This aligns directly with the goal of the issue:

> “Implementing the library on the landing page or a demo page where developers can test the state, capital, or town directly on the page to verify the data.”

---

##  Files Added / Updated

* `components/DemoTester.jsx` 
* `App.jsx`
<img width="1366" height="602" alt="image" src="https://github.com/user-attachments/assets/f40cf328-a9bf-45fe-bafd-60fe7cae8fbf" />
